### PR TITLE
fix: move up will go to line end if shorter

### DIFF
--- a/view.v
+++ b/view.v
@@ -234,6 +234,15 @@ fn (view mut View) k() {
 	if view.y < view.from && view.y > 0 {
 		view.from--
 	}
+	// Line above is shorter, move to the end of it
+	line := view.line()
+	if view.x > line.len - 1 {
+		view.prev_x = view.x
+		view.x = line.len - 1
+		if view.x < 0 {
+			view.x = 0
+		}
+	}
 }
 
 fn (view mut View) H() {


### PR DESCRIPTION
The cursor will go to the end of the line if the line above is shorter when moving up.
(Same behavior as moving down)