### PR TITLE
Fix crash when pressing o key on an empty file

### DIFF
--- a/view.v
+++ b/view.v
@@ -425,8 +425,6 @@ fn (view mut View) p() {
 
 fn (view mut View) o() {
 	view.y++
-	lines := view.lines
-	view.lines = lines
 	// Insert the same amount of spaces/tabs as in prev line
 	prev_line := view.lines[view.y - 1]
 	mut nr_spaces := 0

--- a/view.v
+++ b/view.v
@@ -426,7 +426,11 @@ fn (view mut View) p() {
 fn (view mut View) o() {
 	view.y++
 	// Insert the same amount of spaces/tabs as in prev line
-	prev_line := view.lines[view.y - 1]
+	prev_line := if view.lines.len == 0 {
+		''
+	} else {
+		view.lines[view.y - 1]
+	}
 	mut nr_spaces := 0
 	mut nr_tabs := 0
 	mut i := 0


### PR DESCRIPTION
The array view.line has length 0 when opening an empty file. Accessing the 0 index of the array will cause a panic. The prev_line is set to an empty string when view.line.len is 0.