### PR TITLE
Fix crash when pressing o key on an empty file

### DIFF
--- a/view.v
+++ b/view.v
@@ -426,7 +426,11 @@ fn (view mut View) p() {
 fn (view mut View) o() {
 	view.y++
 	// Insert the same amount of spaces/tabs as in prev line
-	prev_line := view.lines[view.y - 1]
+	prev_line := if view.lines.len == 0 {
+		''
+	} else {
+		view.lines[view.y - 1]
+	}
 	mut nr_spaces := 0
 	mut nr_tabs := 0
 	mut i := 0


### PR DESCRIPTION
prev_line should be set to an empty string if view.line.len is 0.